### PR TITLE
Fix for request module after v2.16 dropped it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> The NPM module "Request" was removed with Magicmirror `v2.16` This has
+> led to the fact that Magicmirror can no longer be started under
+> Docker, for example. With this fork, the deprecated npm module
+> "Request" is installed locally in the module's directory.
+
 # MMM-Sonos
 
 <p>
@@ -54,6 +59,15 @@ Clone this repository:
 ```
 git clone https://github.com/Snille/MMM-Sonos.git
 ```
+Install Node-Modules
+```
+npm init
+````
+&
+````
+npm install request
+````
+
 
 Add some [config entries](#configuration) to your config.js file. After that the content will be added to your mirror.
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "version": "0.1.0",
+  "dependencies": {
+    "request": "*"
+  }
+}


### PR DESCRIPTION
This pull-request solves the problem that with V2.16 of magicmirror the module request has been removed.

MichMich/MagicMirror#2617